### PR TITLE
.gitignore: ignore __pycache__ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_STORE
+__pycache__


### PR DESCRIPTION
These are internal Python files that we should not store in Git