### PR TITLE
requirements.txt: remove spicy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 psycopg2
 matplotlib
-spicy
 pandas


### PR DESCRIPTION
We think this library is unused, so we don't need it.